### PR TITLE
"username" should be "password"

### DIFF
--- a/ldap-combined/README.md
+++ b/ldap-combined/README.md
@@ -11,4 +11,4 @@ The `build` user exists in LDAP, and the `admin` user is in the `realm.propertie
 
 **Property File User:**
 `username: admin`
-`username: admin`
+`password: admin`


### PR DESCRIPTION
Assumed typo of copy pasta from username which should be password