### PR TITLE
Updated deployment files to modernize for newer Kube networking deplopment

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -71,29 +71,23 @@ kubectl apply -f mysql-deployment.yaml
 
 ### Ingress Controller
 
-For this example, we are using Nginx as an ingress controller, which allows us to use the sticky sessions. Sticky sessions is required for clustered Rundeck.
-
-We are using this ingress controller: https://kubernetes.github.io/ingress-nginx/
-You will need to install it in order to make this example works (see https://kubernetes.github.io/ingress-nginx/deploy/):
-
-
-* First, install the common Nginx components. This is mandatory for any Nginx ingress on Kubernetes.
-
-```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
-
-```
-
-* Next, run the provider specific steps for Nginx ingress (see https://kubernetes.github.io/ingress-nginx/deploy/)
+For this example, we are using Nginx as an ingress controller, which allows us to use the sticky sessions. Sticky sessions is required for clustered Rundeck. You will need to install it in order to make this example works (see https://github.com/kubernetes/ingress-nginx):
 
 On a local Docker Desktop environment:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml
 
 ```
 
-If you are running this in a different environment, please refer to the documentation linked above.
+* If you are running this in a cloud, bare-metal, or other environment, please refer to the documentation link and choose your provider specific setup for Nginx ingress .(see https://kubernetes.github.io/ingress-nginx/deploy/)
+
+After the Ingress is all setup, run the folling to wait until is ready to process requests:
+
+```
+kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
+
+```
 
 ### Create Rundeckpro deployment
 
@@ -104,6 +98,13 @@ kubectl apply -f rundeckpro-deployment.yaml
 
 ```
 
+### Access Rundeck WebUI 
+
+You will need to port-forward the Rundeck service to access and interact with WebUI running in your Kubernetes cluster from your localhost. 
+
+```
+kubectl port-forward service/rundeckpro 8080:8080
+```
 
 ## Uninstall
 

--- a/kubernetes/rundeckpro-deployment.yaml
+++ b/kubernetes/rundeckpro-deployment.yaml
@@ -1,25 +1,25 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: rudeckpro-nginx
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    #for sticky sessions
-    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingres.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-
 spec:
+  ingressClassName: nginx
   rules:
   - host: localhost
     http:
       paths:
-      - backend:
-          serviceName: rundeckpro
-          servicePort: 8080
-        path: /
-
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: rundeckpro
+            port:
+              number: 8080
 ---
 
 apiVersion: v1
@@ -39,7 +39,7 @@ spec:
 
 ---
 
-apiVersion: apps/v1 
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rundeckpro
@@ -47,7 +47,7 @@ metadata:
   labels:
     app: rundeckpro
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: rundeckpro
@@ -71,7 +71,7 @@ spec:
             subPath: config
         env:
         - name: RUNDECK_GRAILS_URL
-          value: "http://localhost"
+          value: "http://localhost:8080"
         - name: RUNDECK_DATABASE_DRIVER
           value: "org.mariadb.jdbc.Driver"
         - name: RUNDECK_DATABASE_URL
@@ -155,4 +155,3 @@ spec:
           items:
           - key: config
             path: config
-            


### PR DESCRIPTION
Changes to include support for the Kubernetes  [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)  spec updated  networking.k8s.io/beta moving to networking.k8s.io/v1.