### PR TITLE
build(docker): add `RUNDECK_GRAILS_URL`

### DIFF
--- a/mysql/docker-compose.yml
+++ b/mysql/docker-compose.yml
@@ -10,6 +10,7 @@ services:
             RUNDECK_DATABASE_USERNAME: rundeck
             RUNDECK_DATABASE_PASSWORD: rundeck
             RUNDECK_DATABASE_URL: jdbc:mysql://mysql/rundeck?autoReconnect=true&useSSL=false
+            RUNDECK_GRAILS_URL: localhost:4440
         volumes:
           - ${RUNDECK_LICENSE_FILE:-/dev/null}:/home/rundeck/etc/rundeckpro-license.key
         ports:

--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -10,6 +10,7 @@ services:
             RUNDECK_DATABASE_USERNAME: rundeck
             RUNDECK_DATABASE_PASSWORD: rundeck
             RUNDECK_DATABASE_URL: jdbc:postgresql://postgres/rundeck?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
+            RUNDECK_GRAILS_URL: localhost:4440
         volumes:
           - ${RUNDECK_LICENSE_FILE:-/dev/null}:/home/rundeck/etc/rundeckpro-license.key
         ports:


### PR DESCRIPTION
## Background

I encountered these issues [Host changes to localhost after first login](https://github.com/rundeck/rundeck/issues/671) and [The basic example redirects to http://127.0.0.1:4440/](https://github.com/rundeck/docker-zoo/issues/4) when running Rundeck using docker-compose.

<br />

## Proposed Solution

Eventually, I added `RUNDECK_GRAILS_URL` in environment section of docker-compose.yml. It states `RUNDECK_GRAILS_URL: localhost:4440` but pretty interchangeable with a remote IP address and a hostname such as https://mywebsite.com as well.

As the [Rundeck docker configuration](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) says, `RUNDECK_GRAILS_URL` controls the base URL the app will use for links, redirects, etc. This is the URL users will use to access the site.

<br />

## Note

I only tested this with MySQL and PostgreSQL.

<br />

Any suggestion is appreciated.