### PR TITLE
fix the login screen to display endless loading

### DIFF
--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             RUNDECK_DATABASE_USERNAME: rundeck
             RUNDECK_DATABASE_PASSWORD: rundeck
             RUNDECK_DATABASE_URL: jdbc:postgresql://postgres/rundeck?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
-            RUNDECK_GRAILS_URL: localhost:4440
+            RUNDECK_GRAILS_URL: http://localhost:4440
         volumes:
           - ${RUNDECK_LICENSE_FILE:-/dev/null}:/home/rundeck/etc/rundeckpro-license.key
         ports:


### PR DESCRIPTION
## Problem I want to fix
When I launch a container with docker-compose up, Rundeck works, but the redirection does not work properly. This causes the login screen to display endless loading without any transition.
After investigating this problem, I realized that it was caused by a redirect error on the browser because the url specified in Location header was incomplete and the protocol was not specified.
This is due to an incorrect specification of the value of RUNDECK_GRAILS_URL.

## What I did
Added the protocol to the value of RUNDECK_GRAILS_URL
